### PR TITLE
See description

### DIFF
--- a/community/tmux/.checksums
+++ b/community/tmux/.checksums
@@ -1,0 +1,1 @@
+ee3ccee391a25d4f2c645c94cde2c144  tmux-3.0a.tar.gz

--- a/community/tmux/spkgbuild
+++ b/community/tmux/spkgbuild
@@ -1,0 +1,16 @@
+# description	: tmux - Terminal multiplexer
+# homepage	: https://tmux.github.io/
+# depends	: libevent ncurses
+# maintainer    : Debdut Chakraborty
+name=tmux
+version=3.0a
+release=1
+source=(https://github.com/tmux/tmux/releases/download/${version}/${name}-${version}.tar.gz)
+
+build() {
+	tar xf ${name}-${version}.tar.gz /tmp
+	cd /tmp
+	./configure --prefix=/usr 
+	make
+	make DESTDIR=$PKG install
+}

--- a/community/virtualbox-latest-modules/.checksums
+++ b/community/virtualbox-latest-modules/.checksums
@@ -1,0 +1,1 @@
+662793ab0d49a3ddffefb449c1f83b84  VirtualBox-6.1.0-135406-Linux_amd64.run

--- a/community/virtualbox-latest-modules/.pkgfiles
+++ b/community/virtualbox-latest-modules/.pkgfiles
@@ -1,0 +1,12 @@
+-rw-r--r-- root/root .pkginstall
+drwxr-xr-x root/root etc/
+drwxr-xr-x root/root etc/modules.d/
+-rw-r--r-- root/root etc/modules.d/virtualbox.conf
+drwxr-xr-x root/root lib/
+drwxr-xr-x root/root lib/modules/
+drwxr-xr-x root/root lib/modules/<kernelversion>/
+drwxr-xr-x root/root lib/modules/<kernelversion>/misc/
+-rw-r--r-- root/root lib/modules/<kernelversion>/misc/vboxdrv.ko.xz
+-rw-r--r-- root/root lib/modules/<kernelversion>/misc/vboxnetadp.ko.xz
+-rw-r--r-- root/root lib/modules/<kernelversion>/misc/vboxnetflt.ko.xz
+-rw-r--r-- root/root lib/modules/<kernelversion>/misc/vboxpci.ko.xz

--- a/community/virtualbox-latest-modules/install
+++ b/community/virtualbox-latest-modules/install
@@ -1,0 +1,18 @@
+# package install script
+
+action=$1
+newversion=$2
+oldversion=$3
+
+post_install() {
+	if [ -f /lib/modules/KERNELVERSION ]; then
+		kernver=$(cat /lib/modules/KERNELVERSION)
+	else
+		kernver=$(file /boot/vmlinuz-venom  | cut -d ' ' -f9)
+	fi
+	/sbin/depmod $kernver
+}
+
+case $action in
+	post-install|post-upgrade) post_install ;;
+esac

--- a/community/virtualbox-latest-modules/spkgbuild
+++ b/community/virtualbox-latest-modules/spkgbuild
@@ -1,0 +1,30 @@
+# description	: Virtualbox(latest) host kernel modules
+# homepage	: http://virtualbox.org/
+# maintainer	: Debdut Chakraborty
+
+name=virtualbox-latest-modules
+version=6.1.0
+release=1
+_release=135406
+
+source=(http://download.virtualbox.org/virtualbox/${version}/VirtualBox-${version}-${_release}-Linux_amd64.run)
+
+build() {
+	sh VirtualBox-${version}-${_release}-Linux_amd64.run --keep --noexec --target $PWD
+	tar xf VirtualBox.tar.bz2 src/vboxhost/	
+
+	[ -f /lib/modules/KERNELVERSION ] && kernver="`cat /lib/modules/KERNELVERSION`" || kernver="`uname -r`"	
+
+	cd src/vboxhost/
+	KERN_VER=$kernver make
+
+	for i in *.ko; do
+	    install -Dm0644 $i $PKG/lib/modules/$kernver/misc/$i
+	done
+
+	install -d $PKG/etc/modules.d/
+	echo "# Load virtualbox modules at startup\nvboxdrv\nvboxnetadp\nvboxnetflt\nvboxpci" > $PKG/etc/modules.d/virtualbox.conf
+
+	# compress modules
+	find $PKG -name '*.ko' -exec xz -T1 {} +
+}

--- a/extra/opera/.checksums
+++ b/extra/opera/.checksums
@@ -1,1 +1,1 @@
-331d9157fbda88dd17323d3776d1439f  opera-stable_58.0.3135.90_amd64.deb
+331d9157fbda88dd17323d3776d1439f  opera-stable_65.0.3467.69_amd64.deb

--- a/extra/opera/spkgbuild
+++ b/extra/opera/spkgbuild
@@ -7,7 +7,7 @@ name=opera
 version=65.0.3467.69
 release=1
 source=(https://download3.operacdn.com/pub/opera/desktop/${version}/linux/${name}-stable_${version}_amd64.deb)
-
+md5sum=(`cut -d" " -f1 .checksums`)
 build() {
 	bsdtar -xf ${name}-stable_${version}_amd64.deb
 	tar xf data.tar.xz -C $PKG

--- a/extra/opera/spkgbuild
+++ b/extra/opera/spkgbuild
@@ -7,7 +7,7 @@ name=opera
 version=65.0.3467.69
 release=1
 source=(https://download3.operacdn.com/pub/opera/desktop/${version}/linux/${name}-stable_${version}_amd64.deb)
-md5sum=(`cut -d" " -f1 .checksums`)
+
 build() {
 	bsdtar -xf ${name}-stable_${version}_amd64.deb
 	tar xf data.tar.xz -C $PKG

--- a/extra/usbutils/.checksums
+++ b/extra/usbutils/.checksums
@@ -1,2 +1,2 @@
-039e851361dcd9f4dc96a7bf66d33f1c  usb.ids
+7efb2af95298613316d6ddcb40604b9b  usb.ids
 0da98eb80159071fdbb00905390509d9  usbutils-012.tar.xz


### PR DESCRIPTION
1 - Fixed checksums.
2 - Added Tmux to the community repo.
3 - Added "virtualbox-latest-modules" to the community repo.

The latest virtualbox has many features unavailable in the 5.2 series which needs to be included for 32bit support, so I created a different port altogether for the latest one. The rest of the packages will be included soon. Whether to add it to the extra repo or not, is up to @emmett1 . I'll be happy to maintain these packages as well.