### PR TITLE
Fix url and version number of htop source

### DIFF
--- a/core/htop/spkgbuild
+++ b/core/htop/spkgbuild
@@ -2,9 +2,9 @@
 # depends	: ncurses python3
 
 name=htop
-version=2.2.0
+version=3.0.2
 release=1
-source="http://hisham.hm/htop/releases/$version/htop-$version.tar.gz"
+source="https://bintray.com/htop/source/download_file?file_path=htop-$version.tar.gz"
 
 build() {
 	cd $name-$version

--- a/core/kdelibs4support/.checksums
+++ b/core/kdelibs4support/.checksums
@@ -1,1 +1,1 @@
-1ee34277264a69f019f38f41d91c569e  kdelibs4support-5.68.0.tar.xz
+51590c1bb39fcbd8ff67de6c57486b74  kdelibs4support-5.74.0.tar.xz

--- a/core/kdelibs4support/spkgbuild
+++ b/core/kdelibs4support/spkgbuild
@@ -2,7 +2,7 @@
 # depends	: kunitconversion kitemmodels kemoticons kded kparts extra-cmake-modules kdoctools qt5 networkmanager perl-uri python3 kdesignerplugin
 
 name=kdelibs4support
-version=5.68.0
+version=5.74.0
 release=1
 source="https://download.kde.org/stable/frameworks/${version::4}/portingAids/$name-$version.tar.xz"
 


### PR DESCRIPTION
Htop source releases have moved and the only versions available are 3.0.0, 3.0.1, and 3.0.2

See: https://htop.dev/downloads.html#sources