### PR TITLE
Correction of gvfs-1.48.1-2 spkgbuild and correction of spotify-client port ( nonfree ) 

### DIFF
--- a/main/gvfs/spkgbuild
+++ b/main/gvfs/spkgbuild
@@ -23,7 +23,7 @@ build() {
 	"
 
 	cd $name-$version
-
+	sed '/policy,/d' -i daemon/meson.build
 	for i in afc goa google gphoto2 mtp nfs smb; do
 		case $i in
 			${name#*-}) _opt="$_opt -D$i=true";;

--- a/nonfree/spotify/.checksums
+++ b/nonfree/spotify/.checksums
@@ -1,2 +1,2 @@
 75aae82b7b33d79bcec25c8783f3ed5c  spotify
-851060d8d9b61f0de263ce090703d28b  spotify-client_1.1.67.586.gbb5ef64e_amd64.deb
+b8523bdf84089bc4b1d7df12411156f6  spotify-client_1.1.72.439.gc253025e_amd64.deb

--- a/nonfree/spotify/spkgbuild
+++ b/nonfree/spotify/spkgbuild
@@ -19,6 +19,5 @@ build() {
 			$PKG/usr/share/icons/hicolor/${size}x${size}/apps/spotify.png
 	done
 	tar -xvf data.tar.gz 
-	#cp usr/bin/spotify /usr/bin
 	
 }

--- a/nonfree/spotify/spkgbuild
+++ b/nonfree/spotify/spkgbuild
@@ -2,7 +2,7 @@
 # depends	: alsa-lib gtk2 glib nss libxtst libx11 openssl libcurl-gnutls gconf libarchive
 
 name=spotify
-version=1.1.67.586.gbb5ef64e
+version=1.1.72.439.gc253025e
 release=1
 source="http://repository.spotify.com/pool/non-free/s/spotify-client/spotify-client_${version}_amd64.deb
 	spotify"
@@ -18,6 +18,7 @@ build() {
 		install -D $PKG/usr/share/spotify/icons/spotify-linux-$size.png \
 			$PKG/usr/share/icons/hicolor/${size}x${size}/apps/spotify.png
 	done
-
-	chmod -R go-w $PKG
+	tar -xvf data.tar.gz 
+	#cp usr/bin/spotify /usr/bin
+	
 }


### PR DESCRIPTION
Correction of an error that not allowed compilation during update (gvfs) and correcting the spotify-client port which was outdated and impossible to compile due to the suppression of the inital sources. 