### PR TITLE
updated telegram-desktop-bin and iproute2 versions + timeshift and iproute2 deps

### DIFF
--- a/main/iproute2/.checksums
+++ b/main/iproute2/.checksums
@@ -1,1 +1,1 @@
-994c1bad2a24aa9d70e89670c5b5dfcb  iproute2-5.16.0.tar.xz
+8ade96ee93f37fba7e1beec89f1a54bf  iproute2-5.17.0.tar.xz

--- a/main/iproute2/.pkgfiles
+++ b/main/iproute2/.pkgfiles
@@ -1,4 +1,4 @@
-iproute2-5.16.0-1
+iproute2-5.17.0-1
 drwxr-xr-x root/root    etc/
 drwxr-xr-x root/root    etc/iproute2/
 -rw-r--r-- root/root    etc/iproute2/bpf_pinning

--- a/main/iproute2/spkgbuild
+++ b/main/iproute2/spkgbuild
@@ -2,7 +2,7 @@
 # depends	: elfutils libcap
 
 name=iproute2
-version=5.16.0
+version=5.17.0
 release=1
 source="https://www.kernel.org/pub/linux/utils/net/$name/$name-$version.tar.xz"
 

--- a/main/iproute2/spkgbuild
+++ b/main/iproute2/spkgbuild
@@ -1,5 +1,5 @@
 # description	: Programs for basic and advanced IPV4-based networking
-# depends	: elfutils libcap
+# depends	: elfutils libcap libmnl
 
 name=iproute2
 version=5.17.0

--- a/main/telegram-desktop-bin/.checksums
+++ b/main/telegram-desktop-bin/.checksums
@@ -6,4 +6,4 @@
 de42b37ab7da90eaf986e4cdb09c991a  icon512.png
 60c432ca6ea7851ce54dde5034b4c397  icon64.png
 fa93a0c669b5f0cd8b9be4c8eecf5cdd  telegram-desktop-bin.desktop
-2f0283912edf5e37c91ca652f3077fec  tsetup.3.1.0.tar.xz
+ccf9d32d5877c3ddd79f221ebf2b4b22  tsetup.3.6.0.tar.xz

--- a/main/telegram-desktop-bin/.pkgfiles
+++ b/main/telegram-desktop-bin/.pkgfiles
@@ -1,4 +1,4 @@
-telegram-desktop-bin-3.1.0-1
+telegram-desktop-bin-3.6.0-1
 drwxr-xr-x root/root    usr/
 drwxr-xr-x root/root    usr/bin/
 -rwxr-xr-x root/root    usr/bin/telegram-desktop

--- a/main/telegram-desktop-bin/spkgbuild
+++ b/main/telegram-desktop-bin/spkgbuild
@@ -2,7 +2,7 @@
 # depends	: glib hicolor-icon-theme dbus libx11 chrpath
 
 name=telegram-desktop-bin
-version=3.1.0
+version=3.6.0
 release=1
 source="https://updates.tdesktop.com/tlinux/tsetup.$version.tar.xz
 	$name.desktop

--- a/main/timeshift/spkgbuild
+++ b/main/timeshift/spkgbuild
@@ -1,5 +1,5 @@
 # description	: A system restore utility for Linux
-# depends	: cronie libgee vte3 gtk3 vala json-glib
+# depends	: cronie libgee vte3 gtk3 vala json-glib rsync
 
 name=timeshift
 version=21.09.1


### PR DESCRIPTION
Timeshift gave an error about missing rsync.
Iproute2's dev suggest to include libmnl or we may be missing some features: https://patchwork.ozlabs.org/project/netdev/patch/20180531193209.27406-1-stephen@networkplumber.org/