### PR TITLE
Update & fix qtwebengine

### DIFF
--- a/main/qtwebengine/.checksums
+++ b/main/qtwebengine/.checksums
@@ -1,3 +1,2 @@
-a5c56326b113bae994283063134b78eb  qtwebengine-5.15.6-5.15.7-1.patch
-af799617842cca0b765102c312fbdd46  qtwebengine-5.15.6.tar.xz
-bafcd8b9d178a3c091d4dd50264f0b30  qtwebengine-5.15.7-build_fixes-1.patch
+d0b0a8522146bbe0d17e1eae8d404ace  qtwebengine-5.15.8-build_fixes-1.patch
+e9ff105f86c94bd302773a78db0d9738  qtwebengine-5.15.8.tar.xz

--- a/main/qtwebengine/.pkgfiles
+++ b/main/qtwebengine/.pkgfiles
@@ -1,19 +1,19 @@
-qtwebengine-5.15.6-1
+qtwebengine-5.15.8-1
 drwxr-xr-x root/root    usr/
 drwxr-xr-x root/root    usr/include/
 drwxr-xr-x root/root    usr/include/qt5/
 drwxr-xr-x root/root    usr/include/qt5/QtPdf/
-drwxr-xr-x root/root    usr/include/qt5/QtPdf/5.15.7/
-drwxr-xr-x root/root    usr/include/qt5/QtPdf/5.15.7/QtPdf/
-drwxr-xr-x root/root    usr/include/qt5/QtPdf/5.15.7/QtPdf/private/
--rw-r--r-- root/root    usr/include/qt5/QtPdf/5.15.7/QtPdf/private/qpdfdestination_p.h
--rw-r--r-- root/root    usr/include/qt5/QtPdf/5.15.7/QtPdf/private/qpdfdocument_p.h
--rw-r--r-- root/root    usr/include/qt5/QtPdf/5.15.7/QtPdf/private/qpdflinkmodel_p.h
--rw-r--r-- root/root    usr/include/qt5/QtPdf/5.15.7/QtPdf/private/qpdflinkmodel_p_p.h
--rw-r--r-- root/root    usr/include/qt5/QtPdf/5.15.7/QtPdf/private/qpdfsearchmodel_p.h
--rw-r--r-- root/root    usr/include/qt5/QtPdf/5.15.7/QtPdf/private/qpdfsearchresult_p.h
--rw-r--r-- root/root    usr/include/qt5/QtPdf/5.15.7/QtPdf/private/qpdfselection_p.h
--rw-r--r-- root/root    usr/include/qt5/QtPdf/5.15.7/QtPdf/private/qtpdf-config_p.h
+drwxr-xr-x root/root    usr/include/qt5/QtPdf/5.15.8/
+drwxr-xr-x root/root    usr/include/qt5/QtPdf/5.15.8/QtPdf/
+drwxr-xr-x root/root    usr/include/qt5/QtPdf/5.15.8/QtPdf/private/
+-rw-r--r-- root/root    usr/include/qt5/QtPdf/5.15.8/QtPdf/private/qpdfdestination_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtPdf/5.15.8/QtPdf/private/qpdfdocument_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtPdf/5.15.8/QtPdf/private/qpdflinkmodel_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtPdf/5.15.8/QtPdf/private/qpdflinkmodel_p_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtPdf/5.15.8/QtPdf/private/qpdfsearchmodel_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtPdf/5.15.8/QtPdf/private/qpdfsearchresult_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtPdf/5.15.8/QtPdf/private/qpdfselection_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtPdf/5.15.8/QtPdf/private/qtpdf-config_p.h
 -rw-r--r-- root/root    usr/include/qt5/QtPdf/QPdfBookmarkModel
 -rw-r--r-- root/root    usr/include/qt5/QtPdf/QPdfDestination
 -rw-r--r-- root/root    usr/include/qt5/QtPdf/QPdfDocument
@@ -40,11 +40,11 @@ drwxr-xr-x root/root    usr/include/qt5/QtPdf/5.15.7/QtPdf/private/
 -rw-r--r-- root/root    usr/include/qt5/QtPdf/qtpdfglobal.h
 -rw-r--r-- root/root    usr/include/qt5/QtPdf/qtpdfversion.h
 drwxr-xr-x root/root    usr/include/qt5/QtPdfWidgets/
-drwxr-xr-x root/root    usr/include/qt5/QtPdfWidgets/5.15.7/
-drwxr-xr-x root/root    usr/include/qt5/QtPdfWidgets/5.15.7/QtPdfWidgets/
-drwxr-xr-x root/root    usr/include/qt5/QtPdfWidgets/5.15.7/QtPdfWidgets/private/
--rw-r--r-- root/root    usr/include/qt5/QtPdfWidgets/5.15.7/QtPdfWidgets/private/qpdfview_p.h
--rw-r--r-- root/root    usr/include/qt5/QtPdfWidgets/5.15.7/QtPdfWidgets/private/qtpdfwidgets-config_p.h
+drwxr-xr-x root/root    usr/include/qt5/QtPdfWidgets/5.15.8/
+drwxr-xr-x root/root    usr/include/qt5/QtPdfWidgets/5.15.8/QtPdfWidgets/
+drwxr-xr-x root/root    usr/include/qt5/QtPdfWidgets/5.15.8/QtPdfWidgets/private/
+-rw-r--r-- root/root    usr/include/qt5/QtPdfWidgets/5.15.8/QtPdfWidgets/private/qpdfview_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtPdfWidgets/5.15.8/QtPdfWidgets/private/qtpdfwidgets-config_p.h
 -rw-r--r-- root/root    usr/include/qt5/QtPdfWidgets/QPdfView
 -rw-r--r-- root/root    usr/include/qt5/QtPdfWidgets/QtPdfWidgets
 -rw-r--r-- root/root    usr/include/qt5/QtPdfWidgets/QtPdfWidgetsDepends
@@ -54,33 +54,33 @@ drwxr-xr-x root/root    usr/include/qt5/QtPdfWidgets/5.15.7/QtPdfWidgets/private
 -rw-r--r-- root/root    usr/include/qt5/QtPdfWidgets/qtpdfwidgetsglobal.h
 -rw-r--r-- root/root    usr/include/qt5/QtPdfWidgets/qtpdfwidgetsversion.h
 drwxr-xr-x root/root    usr/include/qt5/QtWebEngine/
-drwxr-xr-x root/root    usr/include/qt5/QtWebEngine/5.15.7/
-drwxr-xr-x root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/
-drwxr-xr-x root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebengineaction_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebengineaction_p_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebenginecertificateerror_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebengineclientcertificateselection_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebenginecontextmenurequest_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebenginedialogrequests_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebenginedownloaditem_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebenginedownloaditem_p_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebenginefaviconprovider_p_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebenginehistory_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebenginehistory_p_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebengineloadrequest_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebenginenavigationrequest_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebenginenewviewrequest_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebengineprofile_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebenginescript_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebenginesettings_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebenginesingleton_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebenginetestsupport_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebenginetouchhandleprovider_p_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebengineview_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qquickwebengineview_p_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qtwebengine-config_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/qtwebengineglobal_p.h
+drwxr-xr-x root/root    usr/include/qt5/QtWebEngine/5.15.8/
+drwxr-xr-x root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/
+drwxr-xr-x root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebengineaction_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebengineaction_p_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebenginecertificateerror_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebengineclientcertificateselection_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebenginecontextmenurequest_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebenginedialogrequests_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebenginedownloaditem_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebenginedownloaditem_p_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebenginefaviconprovider_p_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebenginehistory_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebenginehistory_p_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebengineloadrequest_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebenginenavigationrequest_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebenginenewviewrequest_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebengineprofile_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebenginescript_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebenginesettings_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebenginesingleton_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebenginetestsupport_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebenginetouchhandleprovider_p_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebengineview_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qquickwebengineview_p_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qtwebengine-config_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngine/5.15.8/QtWebEngine/private/qtwebengineglobal_p.h
 -rw-r--r-- root/root    usr/include/qt5/QtWebEngine/QQuickWebEngineProfile
 -rw-r--r-- root/root    usr/include/qt5/QtWebEngine/QQuickWebEngineScript
 -rw-r--r-- root/root    usr/include/qt5/QtWebEngine/QtWebEngine
@@ -92,15 +92,15 @@ drwxr-xr-x root/root    usr/include/qt5/QtWebEngine/5.15.7/QtWebEngine/private/
 -rw-r--r-- root/root    usr/include/qt5/QtWebEngine/qtwebengineglobal.h
 -rw-r--r-- root/root    usr/include/qt5/QtWebEngine/qtwebengineversion.h
 drwxr-xr-x root/root    usr/include/qt5/QtWebEngineCore/
-drwxr-xr-x root/root    usr/include/qt5/QtWebEngineCore/5.15.7/
-drwxr-xr-x root/root    usr/include/qt5/QtWebEngineCore/5.15.7/QtWebEngineCore/
-drwxr-xr-x root/root    usr/include/qt5/QtWebEngineCore/5.15.7/QtWebEngineCore/private/
--rw-r--r-- root/root    usr/include/qt5/QtWebEngineCore/5.15.7/QtWebEngineCore/private/qtwebenginecore-config_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngineCore/5.15.7/QtWebEngineCore/private/qtwebenginecoreglobal_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngineCore/5.15.7/QtWebEngineCore/private/qwebenginecallback_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngineCore/5.15.7/QtWebEngineCore/private/qwebenginecookiestore_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngineCore/5.15.7/QtWebEngineCore/private/qwebenginemessagepumpscheduler_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngineCore/5.15.7/QtWebEngineCore/private/qwebengineurlrequestinfo_p.h
+drwxr-xr-x root/root    usr/include/qt5/QtWebEngineCore/5.15.8/
+drwxr-xr-x root/root    usr/include/qt5/QtWebEngineCore/5.15.8/QtWebEngineCore/
+drwxr-xr-x root/root    usr/include/qt5/QtWebEngineCore/5.15.8/QtWebEngineCore/private/
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngineCore/5.15.8/QtWebEngineCore/private/qtwebenginecore-config_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngineCore/5.15.8/QtWebEngineCore/private/qtwebenginecoreglobal_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngineCore/5.15.8/QtWebEngineCore/private/qwebenginecallback_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngineCore/5.15.8/QtWebEngineCore/private/qwebenginecookiestore_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngineCore/5.15.8/QtWebEngineCore/private/qwebenginemessagepumpscheduler_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngineCore/5.15.8/QtWebEngineCore/private/qwebengineurlrequestinfo_p.h
 -rw-r--r-- root/root    usr/include/qt5/QtWebEngineCore/QWebEngineCallback
 -rw-r--r-- root/root    usr/include/qt5/QtWebEngineCore/QWebEngineClientCertificateStore
 -rw-r--r-- root/root    usr/include/qt5/QtWebEngineCore/QWebEngineCookieStore
@@ -134,17 +134,17 @@ drwxr-xr-x root/root    usr/include/qt5/QtWebEngineCore/5.15.7/QtWebEngineCore/p
 -rw-r--r-- root/root    usr/include/qt5/QtWebEngineCore/qwebengineurlscheme.h
 -rw-r--r-- root/root    usr/include/qt5/QtWebEngineCore/qwebengineurlschemehandler.h
 drwxr-xr-x root/root    usr/include/qt5/QtWebEngineWidgets/
-drwxr-xr-x root/root    usr/include/qt5/QtWebEngineWidgets/5.15.7/
-drwxr-xr-x root/root    usr/include/qt5/QtWebEngineWidgets/5.15.7/QtWebEngineWidgets/
-drwxr-xr-x root/root    usr/include/qt5/QtWebEngineWidgets/5.15.7/QtWebEngineWidgets/private/
--rw-r--r-- root/root    usr/include/qt5/QtWebEngineWidgets/5.15.7/QtWebEngineWidgets/private/qtwebenginewidgets-config_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngineWidgets/5.15.7/QtWebEngineWidgets/private/qwebenginedownloaditem_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngineWidgets/5.15.7/QtWebEngineWidgets/private/qwebenginehistory_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngineWidgets/5.15.7/QtWebEngineWidgets/private/qwebenginenotificationpresenter_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngineWidgets/5.15.7/QtWebEngineWidgets/private/qwebenginepage_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngineWidgets/5.15.7/QtWebEngineWidgets/private/qwebengineprofile_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngineWidgets/5.15.7/QtWebEngineWidgets/private/qwebenginescriptcollection_p.h
--rw-r--r-- root/root    usr/include/qt5/QtWebEngineWidgets/5.15.7/QtWebEngineWidgets/private/qwebengineview_p.h
+drwxr-xr-x root/root    usr/include/qt5/QtWebEngineWidgets/5.15.8/
+drwxr-xr-x root/root    usr/include/qt5/QtWebEngineWidgets/5.15.8/QtWebEngineWidgets/
+drwxr-xr-x root/root    usr/include/qt5/QtWebEngineWidgets/5.15.8/QtWebEngineWidgets/private/
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngineWidgets/5.15.8/QtWebEngineWidgets/private/qtwebenginewidgets-config_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngineWidgets/5.15.8/QtWebEngineWidgets/private/qwebenginedownloaditem_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngineWidgets/5.15.8/QtWebEngineWidgets/private/qwebenginehistory_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngineWidgets/5.15.8/QtWebEngineWidgets/private/qwebenginenotificationpresenter_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngineWidgets/5.15.8/QtWebEngineWidgets/private/qwebenginepage_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngineWidgets/5.15.8/QtWebEngineWidgets/private/qwebengineprofile_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngineWidgets/5.15.8/QtWebEngineWidgets/private/qwebenginescriptcollection_p.h
+-rw-r--r-- root/root    usr/include/qt5/QtWebEngineWidgets/5.15.8/QtWebEngineWidgets/private/qwebengineview_p.h
 -rw-r--r-- root/root    usr/include/qt5/QtWebEngineWidgets/QWebEngineCertificateError
 -rw-r--r-- root/root    usr/include/qt5/QtWebEngineWidgets/QWebEngineClientCertificateSelection
 -rw-r--r-- root/root    usr/include/qt5/QtWebEngineWidgets/QWebEngineContextMenuData
@@ -198,30 +198,30 @@ drwxr-xr-x root/root    usr/lib/cmake/Qt5WebEngineWidgets/
 -rw-r--r-- root/root    usr/lib/cmake/Qt5WebEngineWidgets/Qt5WebEngineWidgetsConfig.cmake
 -rw-r--r-- root/root    usr/lib/cmake/Qt5WebEngineWidgets/Qt5WebEngineWidgetsConfigVersion.cmake
 -rw-r--r-- root/root    usr/lib/libQt5Pdf.prl
-lrwxrwxrwx root/root    usr/lib/libQt5Pdf.so -> libQt5Pdf.so.5.15.7
-lrwxrwxrwx root/root    usr/lib/libQt5Pdf.so.5 -> libQt5Pdf.so.5.15.7
-lrwxrwxrwx root/root    usr/lib/libQt5Pdf.so.5.15 -> libQt5Pdf.so.5.15.7
--rwxr-xr-x root/root    usr/lib/libQt5Pdf.so.5.15.7
+lrwxrwxrwx root/root    usr/lib/libQt5Pdf.so -> libQt5Pdf.so.5.15.8
+lrwxrwxrwx root/root    usr/lib/libQt5Pdf.so.5 -> libQt5Pdf.so.5.15.8
+lrwxrwxrwx root/root    usr/lib/libQt5Pdf.so.5.15 -> libQt5Pdf.so.5.15.8
+-rwxr-xr-x root/root    usr/lib/libQt5Pdf.so.5.15.8
 -rw-r--r-- root/root    usr/lib/libQt5PdfWidgets.prl
-lrwxrwxrwx root/root    usr/lib/libQt5PdfWidgets.so -> libQt5PdfWidgets.so.5.15.7
-lrwxrwxrwx root/root    usr/lib/libQt5PdfWidgets.so.5 -> libQt5PdfWidgets.so.5.15.7
-lrwxrwxrwx root/root    usr/lib/libQt5PdfWidgets.so.5.15 -> libQt5PdfWidgets.so.5.15.7
--rwxr-xr-x root/root    usr/lib/libQt5PdfWidgets.so.5.15.7
+lrwxrwxrwx root/root    usr/lib/libQt5PdfWidgets.so -> libQt5PdfWidgets.so.5.15.8
+lrwxrwxrwx root/root    usr/lib/libQt5PdfWidgets.so.5 -> libQt5PdfWidgets.so.5.15.8
+lrwxrwxrwx root/root    usr/lib/libQt5PdfWidgets.so.5.15 -> libQt5PdfWidgets.so.5.15.8
+-rwxr-xr-x root/root    usr/lib/libQt5PdfWidgets.so.5.15.8
 -rw-r--r-- root/root    usr/lib/libQt5WebEngine.prl
-lrwxrwxrwx root/root    usr/lib/libQt5WebEngine.so -> libQt5WebEngine.so.5.15.7
-lrwxrwxrwx root/root    usr/lib/libQt5WebEngine.so.5 -> libQt5WebEngine.so.5.15.7
-lrwxrwxrwx root/root    usr/lib/libQt5WebEngine.so.5.15 -> libQt5WebEngine.so.5.15.7
--rwxr-xr-x root/root    usr/lib/libQt5WebEngine.so.5.15.7
+lrwxrwxrwx root/root    usr/lib/libQt5WebEngine.so -> libQt5WebEngine.so.5.15.8
+lrwxrwxrwx root/root    usr/lib/libQt5WebEngine.so.5 -> libQt5WebEngine.so.5.15.8
+lrwxrwxrwx root/root    usr/lib/libQt5WebEngine.so.5.15 -> libQt5WebEngine.so.5.15.8
+-rwxr-xr-x root/root    usr/lib/libQt5WebEngine.so.5.15.8
 -rw-r--r-- root/root    usr/lib/libQt5WebEngineCore.prl
-lrwxrwxrwx root/root    usr/lib/libQt5WebEngineCore.so -> libQt5WebEngineCore.so.5.15.7
-lrwxrwxrwx root/root    usr/lib/libQt5WebEngineCore.so.5 -> libQt5WebEngineCore.so.5.15.7
-lrwxrwxrwx root/root    usr/lib/libQt5WebEngineCore.so.5.15 -> libQt5WebEngineCore.so.5.15.7
--rwxr-xr-x root/root    usr/lib/libQt5WebEngineCore.so.5.15.7
+lrwxrwxrwx root/root    usr/lib/libQt5WebEngineCore.so -> libQt5WebEngineCore.so.5.15.8
+lrwxrwxrwx root/root    usr/lib/libQt5WebEngineCore.so.5 -> libQt5WebEngineCore.so.5.15.8
+lrwxrwxrwx root/root    usr/lib/libQt5WebEngineCore.so.5.15 -> libQt5WebEngineCore.so.5.15.8
+-rwxr-xr-x root/root    usr/lib/libQt5WebEngineCore.so.5.15.8
 -rw-r--r-- root/root    usr/lib/libQt5WebEngineWidgets.prl
-lrwxrwxrwx root/root    usr/lib/libQt5WebEngineWidgets.so -> libQt5WebEngineWidgets.so.5.15.7
-lrwxrwxrwx root/root    usr/lib/libQt5WebEngineWidgets.so.5 -> libQt5WebEngineWidgets.so.5.15.7
-lrwxrwxrwx root/root    usr/lib/libQt5WebEngineWidgets.so.5.15 -> libQt5WebEngineWidgets.so.5.15.7
--rwxr-xr-x root/root    usr/lib/libQt5WebEngineWidgets.so.5.15.7
+lrwxrwxrwx root/root    usr/lib/libQt5WebEngineWidgets.so -> libQt5WebEngineWidgets.so.5.15.8
+lrwxrwxrwx root/root    usr/lib/libQt5WebEngineWidgets.so.5 -> libQt5WebEngineWidgets.so.5.15.8
+lrwxrwxrwx root/root    usr/lib/libQt5WebEngineWidgets.so.5.15 -> libQt5WebEngineWidgets.so.5.15.8
+-rwxr-xr-x root/root    usr/lib/libQt5WebEngineWidgets.so.5.15.8
 drwxr-xr-x root/root    usr/lib/pkgconfig/
 -rw-r--r-- root/root    usr/lib/pkgconfig/Qt5Pdf.pc
 -rw-r--r-- root/root    usr/lib/pkgconfig/Qt5PdfWidgets.pc

--- a/main/qtwebengine/spkgbuild
+++ b/main/qtwebengine/spkgbuild
@@ -1,33 +1,31 @@
-# description	: QtWebEngine integrates chromium's web capabilities into Qt
-# depends	: qt5 nss python2 libwebp libxslt opus ninja ffmpeg alsa-lib libxcomposite libxtst libxcursor nodejs
+# description   : QtWebEngine integrates chromium's web capabilities into Qt
+# depends       : qt5 nss python2 libwebp libxslt opus ninja ffmpeg alsa-lib libxcomposite libxtst libxcursor nodejs
 
 name=qtwebengine
-version=5.15.6
+version=5.15.8
 release=1
 source="https://anduin.linuxfromscratch.org/BLFS/qtwebengine/qtwebengine-$version.tar.xz
-	https://www.linuxfromscratch.org/patches/blfs/svn/qtwebengine-$version-5.15.7-1.patch
-	https://www.linuxfromscratch.org/patches/blfs/svn/qtwebengine-5.15.7-build_fixes-1.patch"
+        https://www.linuxfromscratch.org/patches/blfs/svn/qtwebengine-$version-build_fixes-1.patch"
 
 build() {
-	cd $name-$version
+        cd $name-$version
 
-	patch -Np1 -i ../qtwebengine-$version-5.15.7-1.patch
-	patch -Np1 -i ../qtwebengine-5.15.7-build_fixes-1.patch
+        patch -Np1 -i ../qtwebengine-$version-build_fixes-1.patch
 
-	mkdir -pv .git src/3rdparty/chromium/.git
+        mkdir -pv .git src/3rdparty/chromium/.git
 
-	find -type f -name "*.pr[io]" |
-	  xargs sed -i -e 's|INCLUDEPATH += |&$$QTWEBENGINE_ROOT/include |'
+        find -type f -name "*.pr[io]" |
+          xargs sed -i -e 's|INCLUDEPATH += |&$$QTWEBENGINE_ROOT/include |'
 
-	mkdir build
-	cd    build
+        mkdir build
+        cd    build
 
-	test -n $MAKEFLAGS && export NINJAFLAGS="$NINJAFLAGS $MAKEFLAGS"
-	
-	qmake .. -- -proprietary-codecs -system-ffmpeg -webengine-icu
-	make
-	make INSTALL_ROOT=$PKG install
+        test -n $MAKEFLAGS && export NINJAFLAGS="$NINJAFLAGS $MAKEFLAGS"
 
-	find $PKG/usr/ -name \*.prl \
-	   -exec sed -i -e '/^QMAKE_PRL_BUILD_DIR/d' {} \;
+        qmake .. -- -proprietary-codecs -system-ffmpeg -webengine-icu
+        make
+        make INSTALL_ROOT=$PKG install
+
+        find $PKG/usr/ -name \*.prl \
+           -exec sed -i -e '/^QMAKE_PRL_BUILD_DIR/d' {} \;
 }


### PR DESCRIPTION
No clear way to undo commits on github, so I made a new fork and worked from there.

Upgraded qtwebengine to 5.15.8. The port which uses 5.15.6 looks for a patch that isn't online anymore, but it seems to compile and run fine without it.