### PR TITLE
Update libreoffice 7.3.4 and add localization to install a langpack

### DIFF
--- a/nonfree/libreoffice/.checksums
+++ b/nonfree/libreoffice/.checksums
@@ -1,1 +1,1 @@
-f2e63c8b52764566eb9f324281e1de87  LibreOffice_7.3.2_Linux_x86-64_rpm.tar.gz
+1b030f5a1a289f7a4c073c8944f3320e  LibreOffice_7.3.4_Linux_x86-64_rpm.tar.gz

--- a/nonfree/libreoffice/.pkgfiles
+++ b/nonfree/libreoffice/.pkgfiles
@@ -1,4 +1,4 @@
-libreoffice-7.3.2-1
+libreoffice-7.3.4-1
 drwxr-xr-x root/root    opt/
 drwxr-xr-x root/root    opt/libreoffice7.3/
 drwxr-xr-x root/root    opt/libreoffice7.3/help/
@@ -5550,8 +5550,6 @@ drwxr-xr-x root/root    opt/libreoffice7.3/program/classes/
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libfilelo.so
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libfirebird_sdbclo.so
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libflatlo.so
--rwxr-xr-x root/root    opt/libreoffice7.3/program/libfreebl3.so
--rwxr-xr-x root/root    opt/libreoffice7.3/program/libfreeblpriv3.so
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libgcc3_uno.so
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libgpg-error-lo.so.0
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libgpgme.so.11
@@ -5599,11 +5597,6 @@ drwxr-xr-x root/root    opt/libreoffice7.3/program/classes/
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libmysql_jdbclo.so
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libmysqlclo.so
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libnamingservicelo.so
--r--r--r-- root/root    opt/libreoffice7.3/program/libnspr4.so
--rwxr-xr-x root/root    opt/libreoffice7.3/program/libnss3.so
--rwxr-xr-x root/root    opt/libreoffice7.3/program/libnssckbi.so
--rwxr-xr-x root/root    opt/libreoffice7.3/program/libnssdbm3.so
--rwxr-xr-x root/root    opt/libreoffice7.3/program/libnssutil3.so
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libodbclo.so
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libodfgen-0.1-lo.so.1
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libofficebean.so
@@ -5614,8 +5607,6 @@ drwxr-xr-x root/root    opt/libreoffice7.3/program/classes/
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libpdffilterlo.so
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libpdfimportlo.so
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libpdfiumlo.so
--r--r--r-- root/root    opt/libreoffice7.3/program/libplc4.so
--r--r--r-- root/root    opt/libreoffice7.3/program/libplds4.so
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libpostgresql-sdbc-impllo.so
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libpostgresql-sdbclo.so
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libpricinglo.so
@@ -5649,12 +5640,8 @@ drwxr-xr-x root/root    opt/libreoffice7.3/program/classes/
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libsduilo.so
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libslideshowlo.so
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libsmdlo.so
--rwxr-xr-x root/root    opt/libreoffice7.3/program/libsmime3.so
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libsmlo.so
--rwxr-xr-x root/root    opt/libreoffice7.3/program/libsoftokn3.so
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libsolverlo.so
--rwxr-xr-x root/root    opt/libreoffice7.3/program/libsqlite3.so
--rwxr-xr-x root/root    opt/libreoffice7.3/program/libssl3.so
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libstaroffice-0.0-lo.so.0
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libstocserviceslo.so
 -rwxr-xr-x root/root    opt/libreoffice7.3/program/libstoragefdlo.so

--- a/nonfree/libreoffice/spkgbuild
+++ b/nonfree/libreoffice/spkgbuild
@@ -1,10 +1,15 @@
 # description	: Full featured cross platform office suite (binary)
-# depends	: libxinerama libx11 qt5 libxcb glib desktop-file-utils shared-mime-info dbus gtk2 gtk3 fontconfig cups gstreamer gst-plugins-base
+# depends	: libxinerama libx11 libxcb glib desktop-file-utils shared-mime-info dbus gtk3 fontconfig cups gst-plugins-base
 
 name=libreoffice
-version=7.3.2
+version=7.3.4
 release=1
-source="http://download.documentfoundation.org/$name/stable/$version/rpm/x86_64/LibreOffice_${version}_Linux_x86-64_rpm.tar.gz"
+#lang="es" 
+# Add localization to Libreoffice for install another lang pack with lang variable for add it how a second URL in source if you need a different language of the default English US (en-US). Another laguagues can be: Arabic (ar), English GB (en-GB), French (fr), Hindi (hi), Indonesian (id), Malayalam (ml), Portuguese (pt), Russian (ru) ... all languages in:
+# https://es.libreoffice.org/descarga/libreoffice/?type=rpm-x86_64&version=7.3.4&lang=pick
+# Uncomment lang variable and second URL to add it in source and install libreoffice and the language pack that you need.
+
+source="http://download.documentfoundation.org/$name/stable/$version/rpm/x86_64/LibreOffice_${version}_Linux_x86-64_rpm.tar.gz" #https://download.documentfoundation.org/libreoffice/stable/$version/rpm/x86_64/LibreOffice_${version}_Linux_x86-64_rpm_langpack_$lang.tar.gz"
 
 build() {
 	for rpm in $SRC/LibreOffice_${version}*/RPMS/*; do


### PR DESCRIPTION
**lang="es"** 

_Add localization to Libreoffice for install another lang pack with lang variable for add it how a second URL in source if you need a different language of the default English US (en-US). Another laguagues can be: Arabic (ar), English GB (en-GB), French (fr), Hindi (hi), Indonesian (id), Malayalam (ml), Portuguese (pt), Russian (ru) ... all languages in:
 https://es.libreoffice.org/descarga/libreoffice/?type=rpm-x86_64&version=7.3.4&lang=pick
 Uncomment lang variable and second URL to add it in source and install libreoffice and the language pack that you need._

**source="http://download.documentfoundation.org/$name/stable/$version/rpm/x86_64/LibreOffice_${version}_Linux_x86-64_rpm.tar.gz https://download.documentfoundation.org/libreoffice/stable/$version/rpm/x86_64/LibreOffice_${version}_Linux_x86-64_rpm_langpack_$lang.tar.gz"**