### PR TITLE
Update eudev to 3.2.11

### DIFF
--- a/main/eudev/.checksums
+++ b/main/eudev/.checksums
@@ -1,1 +1,1 @@
-60b135a189523f333cea5f71a3345c8d  eudev-3.2.10.tar.gz
+195e60ef0f9587ccb4ec368569c5e4b2  eudev-3.2.11.tar.gz

--- a/main/eudev/.pkgfiles
+++ b/main/eudev/.pkgfiles
@@ -1,9 +1,11 @@
+eudev-3.2.11-1
 drwxr-xr-x root/root    etc/
 drwxr-xr-x root/root    etc/udev/
 drwxr-xr-x root/root    etc/udev/hwdb.d/
 -rw-r--r-- root/root    etc/udev/hwdb.d/20-OUI.hwdb
 -rw-r--r-- root/root    etc/udev/hwdb.d/20-acpi-vendor.hwdb
 -rw-r--r-- root/root    etc/udev/hwdb.d/20-bluetooth-vendor-product.hwdb
+-rw-r--r-- root/root    etc/udev/hwdb.d/20-dmi-id.hwdb
 -rw-r--r-- root/root    etc/udev/hwdb.d/20-net-ifname.hwdb
 -rw-r--r-- root/root    etc/udev/hwdb.d/20-pci-classes.hwdb
 -rw-r--r-- root/root    etc/udev/hwdb.d/20-pci-vendor-model.hwdb
@@ -12,12 +14,20 @@ drwxr-xr-x root/root    etc/udev/hwdb.d/
 -rw-r--r-- root/root    etc/udev/hwdb.d/20-usb-classes.hwdb
 -rw-r--r-- root/root    etc/udev/hwdb.d/20-usb-vendor-model.hwdb
 -rw-r--r-- root/root    etc/udev/hwdb.d/20-vmbus-class.hwdb
+-rw-r--r-- root/root    etc/udev/hwdb.d/60-autosuspend-fingerprint-reader.hwdb
+-rw-r--r-- root/root    etc/udev/hwdb.d/60-autosuspend.hwdb
 -rw-r--r-- root/root    etc/udev/hwdb.d/60-evdev.hwdb
+-rw-r--r-- root/root    etc/udev/hwdb.d/60-input-id.hwdb
 -rw-r--r-- root/root    etc/udev/hwdb.d/60-keyboard.hwdb
+-rw-r--r-- root/root    etc/udev/hwdb.d/60-seat.hwdb
 -rw-r--r-- root/root    etc/udev/hwdb.d/60-sensor.hwdb
+-rw-r--r-- root/root    etc/udev/hwdb.d/70-analyzers.hwdb
+-rw-r--r-- root/root    etc/udev/hwdb.d/70-cameras.hwdb
+-rw-r--r-- root/root    etc/udev/hwdb.d/70-joystick.hwdb
 -rw-r--r-- root/root    etc/udev/hwdb.d/70-mouse.hwdb
 -rw-r--r-- root/root    etc/udev/hwdb.d/70-pointingstick.hwdb
 -rw-r--r-- root/root    etc/udev/hwdb.d/70-touchpad.hwdb
+-rw-r--r-- root/root    etc/udev/hwdb.d/80-ieee1394-unit-function.hwdb
 drwxr-xr-x root/root    etc/udev/rules.d/
 -rw-r--r-- root/root    etc/udev/udev.conf
 drwxr-xr-x root/root    lib/

--- a/main/eudev/spkgbuild
+++ b/main/eudev/spkgbuild
@@ -2,13 +2,13 @@
 # depends	: util-linux kmod
 
 name=eudev
-version=3.2.10
+version=3.2.11
 release=1
-source="https://dev.gentoo.org/~blueness/$name/$name-$version.tar.gz"
+source="$name-$version.tar.gz::https://github.com/eudev-project/eudev/archive/v$version.tar.gz"
 
 build() {
 	cd $name-$version
-
+	NOCONFIGURE=1 ./autogen.sh
 	./configure --prefix=/usr           \
 	            --bindir=/sbin          \
 	            --sbindir=/sbin         \


### PR DESCRIPTION
This is a project started by Gentoo developers and testing was initially being done mostly on OpenRC. We welcome contribution from others using a variety of system initializations to ensure eudev remains system initialization and distribution neutral. On 2021-08-20 Gentoo decided to abandon eudev and a new project was established on 2021-09-14 by Alpine, Devuan and Gentoo contributors (alphabetical order).

