### PR TITLE
Update glibmm to 2.66

### DIFF
--- a/main/glibmm/.checksums
+++ b/main/glibmm/.checksums
@@ -1,1 +1,1 @@
-02c40e6bc0721c564e4b033a18cb3a8e  glibmm-2.64.5.tar.xz
+142b17a892574f75f25883a5f9137264  glibmm-2.66.4.tar.xz

--- a/main/glibmm/.pkgfiles
+++ b/main/glibmm/.pkgfiles
@@ -1,4 +1,4 @@
-glibmm-2.64.5-1
+glibmm-2.66.4-1
 drwxr-xr-x root/root    usr/
 drwxr-xr-x root/root    usr/include/
 drwxr-xr-x root/root    usr/include/giomm-2.4/

--- a/main/glibmm/spkgbuild
+++ b/main/glibmm/spkgbuild
@@ -2,13 +2,14 @@
 # depends	: glib libsigc++ meson
 
 name=glibmm
-version=2.64.5
+_name=glibmm
+version=2.66.4
 release=1
-source="https://ftp.gnome.org/pub/gnome/sources/$name/${version%.*}/$name-$version.tar.xz"
+source="https://ftp.gnome.org/pub/gnome/sources/$_name/${version%.*}/$_name-$version.tar.xz"
 
 build() {
-	cd $name-$version
-	venom-meson build
+	cd $_name-$version
+	venom-meson build --wrap-mode nofallback
 	meson compile -C build
 	DESTDIR=$PKG meson install -C build
 }


### PR DESCRIPTION
All it's dependencies compile good with this version and it's needed by telegram-desktop