### PR TITLE
Fix linux-firmware: correct dangling symlinks

### DIFF
--- a/main/linux-firmware/.checksums
+++ b/main/linux-firmware/.checksums
@@ -1,1 +1,2 @@
+d8ffb48719787ad6ea87fbe1f23a0690  WHENCE-Correct-dangling-symlinks.patch
 313489c6308af9e87b9ae4dace5a9b86  linux-firmware-20220708.tar.gz

--- a/main/linux-firmware/.pkgfiles
+++ b/main/linux-firmware/.pkgfiles
@@ -1,4 +1,4 @@
-linux-firmware-20220708-1
+linux-firmware-20220708-2
 drwxr-xr-x root/root    lib/
 drwxr-xr-x root/root    lib/firmware/
 drwxr-xr-x root/root    lib/firmware/3com/
@@ -835,7 +835,7 @@ lrwxrwxrwx root/root    lib/firmware/brcm/brcmfmac43430-sdio.starfive,visionfive
 -rw-r--r-- root/root    lib/firmware/brcm/brcmfmac43430a0-sdio.bin
 -rw-r--r-- root/root    lib/firmware/brcm/brcmfmac43430a0-sdio.ilife-S806.txt
 -rw-r--r-- root/root    lib/firmware/brcm/brcmfmac43430a0-sdio.jumper-ezpad-mini3.txt
-lrwxrwxrwx root/root    lib/firmware/brcm/brcmfmac43455-sdio.AW-CM256SM.txt -> brcmfmac43455-sdio.pine64,quartz64-b.txt
+-rw-r--r-- root/root    lib/firmware/brcm/brcmfmac43455-sdio.AW-CM256SM.txt
 -rw-r--r-- root/root    lib/firmware/brcm/brcmfmac43455-sdio.MINIX-NEO Z83-4.txt
 lrwxrwxrwx root/root    lib/firmware/brcm/brcmfmac43455-sdio.Raspberry Pi Foundation-Raspberry Pi 4 Model B.txt -> brcmfmac43455-sdio.raspberrypi,4-model-b.txt
 lrwxrwxrwx root/root    lib/firmware/brcm/brcmfmac43455-sdio.Raspberry Pi Foundation-Raspberry Pi Compute Module 4.txt -> brcmfmac43455-sdio.raspberrypi,4-model-b.txt
@@ -872,6 +872,10 @@ lrwxrwxrwx root/root    lib/firmware/brcm/brcmfmac4373-sdio.clm_blob -> ../cypre
 -rw-r--r-- root/root    lib/firmware/brcm/brcmfmac4373.bin
 lrwxrwxrwx root/root    lib/firmware/brcm/brcmfmac54591-pcie.bin -> ../cypress/cyfmac54591-pcie.bin
 lrwxrwxrwx root/root    lib/firmware/brcm/brcmfmac54591-pcie.clm_blob -> ../cypress/cyfmac54591-pcie.clm_blob
+lrwxrwxrwx root/root    lib/firmware/brcmfmac43455-sdio.beagle,am5729-beagleboneai.txt -> brcm/brcmfmac43455-sdio.AW-CM256SM.txt
+lrwxrwxrwx root/root    lib/firmware/brcmfmac43455-sdio.pine64,pinebook-pro.txt -> brcm/brcmfmac43455-sdio.AW-CM256SM.txt
+lrwxrwxrwx root/root    lib/firmware/brcmfmac43455-sdio.pine64,pinephone-pro.txt -> brcm/brcmfmac43455-sdio.AW-CM256SM.txt
+lrwxrwxrwx root/root    lib/firmware/brcmfmac43455-sdio.pine64,quartz64-b.txt -> brcm/brcmfmac43455-sdio.AW-CM256SM.txt
 drwxr-xr-x root/root    lib/firmware/cadence/
 -rw-r--r-- root/root    lib/firmware/cadence/mhdp8546.bin
 -rw-r--r-- root/root    lib/firmware/carl9170-1.fw

--- a/main/linux-firmware/WHENCE-Correct-dangling-symlinks.patch
+++ b/main/linux-firmware/WHENCE-Correct-dangling-symlinks.patch
@@ -1,0 +1,37 @@
+From dfa29317dd78f3a18f37ef8063efe9d2659e6387 Mon Sep 17 00:00:00 2001
+From: Mario Limonciello <mario.limonciello@amd.com>
+Date: Fri, 8 Jul 2022 11:09:51 -0500
+Subject: WHENCE: Correct dangling symlinks
+
+The symlink direction was wrong for some brcm firmware.
+
+Fixes: f8a2651a ("Link some devices that ship with the AW-CM256SM")
+Signed-off-by: Mario Limonciello <mario.limonciello@amd.com>
+Reviewed-by: Peter Robinson <pbrobinson@gmail.com>
+Signed-off-by: Josh Boyer <jwboyer@kernel.org>
+---
+ WHENCE | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/WHENCE b/WHENCE
+index 14f3472..14d0a87 100644
+--- a/WHENCE
++++ b/WHENCE
+@@ -2820,10 +2820,10 @@ Link: brcm/brcmfmac4356-sdio.firefly,firefly-rk3399.txt -> brcmfmac4356-sdio.AP6
+ Link: brcm/brcmfmac4356-sdio.khadas,vim2.txt -> brcmfmac4356-sdio.AP6356S.txt
+ Link: brcm/brcmfmac4356-sdio.vamrs,rock960.txt -> brcmfmac4356-sdio.AP6356S.txt
+ File: brcm/brcmfmac43455-sdio.AW-CM256SM.txt
+-Link: brcm/brcmfmac43455-sdio.AW-CM256SM.txt -> brcmfmac43455-sdio.beagle,am5729-beagleboneai.txt
+-Link: brcm/brcmfmac43455-sdio.AW-CM256SM.txt -> brcmfmac43455-sdio.pine64,pinebook-pro.txt
+-Link: brcm/brcmfmac43455-sdio.AW-CM256SM.txt -> brcmfmac43455-sdio.pine64,pinephone-pro.txt
+-Link: brcm/brcmfmac43455-sdio.AW-CM256SM.txt -> brcmfmac43455-sdio.pine64,quartz64-b.txt
++Link: brcmfmac43455-sdio.beagle,am5729-beagleboneai.txt -> brcm/brcmfmac43455-sdio.AW-CM256SM.txt
++Link: brcmfmac43455-sdio.pine64,pinebook-pro.txt -> brcm/brcmfmac43455-sdio.AW-CM256SM.txt
++Link: brcmfmac43455-sdio.pine64,pinephone-pro.txt -> brcm/brcmfmac43455-sdio.AW-CM256SM.txt
++Link: brcmfmac43455-sdio.pine64,quartz64-b.txt -> brcm/brcmfmac43455-sdio.AW-CM256SM.txt
+ 
+ Licence: GPLv2. See GPL-2 for details.
+ 
+-- 
+cgit 
+

--- a/main/linux-firmware/spkgbuild
+++ b/main/linux-firmware/spkgbuild
@@ -2,12 +2,13 @@
 
 name=linux-firmware
 version=20220708
-release=1
-source="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/linux-firmware-$version.tar.gz"
+release=2
+source="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/linux-firmware-$version.tar.gz 
+	WHENCE-Correct-dangling-symlinks.patch"
 
 build() {
 	cd $name-$version
-
+	patch -Np1 -i ../WHENCE-Correct-dangling-symlinks.patch
 	make DESTDIR=$PKG install
 	#rm $PKG/lib/firmware/{Makefile,README,configure,GPL-3,*.txt,check_whence.py}
 }

--- a/main/linux-firmware/spkgbuild
+++ b/main/linux-firmware/spkgbuild
@@ -8,7 +8,10 @@ source="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.
 
 build() {
 	cd $name-$version
+	
+	# Correct dangling symlinks. The symlink direction was wrong for some brcm firmware.
 	patch -Np1 -i ../WHENCE-Correct-dangling-symlinks.patch
+
 	make DESTDIR=$PKG install
 	#rm $PKG/lib/firmware/{Makefile,README,configure,GPL-3,*.txt,check_whence.py}
 }


### PR DESCRIPTION
The symlink direction was wrong for some brcm firmware.
