### PR TITLE
Fix: grub 2.06 reboots immediately when compiled with -O2, only BIOS

### DIFF
--- a/main/grub/.pkgfiles
+++ b/main/grub/.pkgfiles
@@ -1,4 +1,4 @@
-grub-2.06-1
+grub-2.06-2
 drwxr-xr-x root/root    etc/
 drwxr-xr-x root/root    etc/bash_completion.d/
 -rw-r--r-- root/root    etc/bash_completion.d/grub
@@ -31,6 +31,7 @@ drwxr-xr-x root/root    usr/bin/
 -rwxr-xr-x root/root    usr/bin/grub-glue-efi
 -rwxr-xr-x root/root    usr/bin/grub-kbdcomp
 -rwxr-xr-x root/root    usr/bin/grub-menulst2cfg
+-rwxr-xr-x root/root    usr/bin/grub-mkfont
 -rwxr-xr-x root/root    usr/bin/grub-mkimage
 -rwxr-xr-x root/root    usr/bin/grub-mklayout
 -rwxr-xr-x root/root    usr/bin/grub-mknetdir

--- a/main/grub/spkgbuild
+++ b/main/grub/spkgbuild
@@ -3,13 +3,18 @@
 
 name=grub
 version=2.06
-release=1
+release=2
 backup="etc/default/grub"
 source="https://ftp.gnu.org/gnu/$name/$name-$version.tar.xz
 	grub.default
 	detect-venom-fallback-initrd.patch"
 
 build() {
+	# workaround for https://savannah.gnu.org/bugs/?60458
+ 	# some more info: https://www.linuxquestions.org/questions/showthread.php?p=6257712
+	# grub 2.06 reboots immediately when compiled with -O2,	only affects legacy BIOS
+	export CFLAGS="-march=x86-64 -pipe -Os"
+
 	cd $name-$version
 
 	patch -Np1 -i $SRC/detect-venom-fallback-initrd.patch


### PR DESCRIPTION
workaround for https://savannah.gnu.org/bugs/?60458

some more info: https://www.linuxquestions.org/questions/showthread.php?p=6257712

grub 2.06 reboots immediately when compiled with -O2, only affects legacy BIOS.