### PR TITLE
Fix build harfbuzz-icu

### DIFF
--- a/main/harfbuzz-icu/spkgbuild
+++ b/main/harfbuzz-icu/spkgbuild
@@ -17,6 +17,6 @@ build() {
 
 	mkdir -p $PKG/usr/lib/pkgconfig $PKG/usr/include/harfbuzz
 	mv PKG/usr/include/harfbuzz/hb-icu.h $PKG/usr/include/harfbuzz/
-	mv PKG/usr/lib/libharfbuzz-icu* $PKG/usr/lib/
-	mv PKG/usr/lib/pkgconfig/harfbuzz-icu.pc $PKG/usr/lib/pkgconfig/
+	mv PKG/usr/lib64/libharfbuzz-icu* $PKG/usr/lib/
+	mv PKG/usr/lib64/pkgconfig/harfbuzz-icu.pc $PKG/usr/lib/pkgconfig/
 }


### PR DESCRIPTION
In this version change the PKG/usr/lib directory to PKG/usr/lib64, now build fine.