### PR TITLE
Revert "Update grep to 3.8"

### DIFF
--- a/main/grep/.checksums
+++ b/main/grep/.checksums
@@ -1,1 +1,1 @@
-dc6e4d18d4659e6e7552fc4a183c8ac9  grep-3.8.tar.xz
+7c9cca97fa18670a21e72638c3e1dabf  grep-3.7.tar.xz

--- a/main/grep/.pkgfiles
+++ b/main/grep/.pkgfiles
@@ -1,4 +1,4 @@
-grep-3.8-1
+grep-3.7-1
 drwxr-xr-x root/root    bin/
 -rwxr-xr-x root/root    bin/egrep
 -rwxr-xr-x root/root    bin/fgrep
@@ -9,4 +9,6 @@ drwxr-xr-x root/root    usr/share/info/
 -rw-r--r-- root/root    usr/share/info/grep.info.gz
 drwxr-xr-x root/root    usr/share/man/
 drwxr-xr-x root/root    usr/share/man/man1/
+-rw-r--r-- root/root    usr/share/man/man1/egrep.1.gz
+-rw-r--r-- root/root    usr/share/man/man1/fgrep.1.gz
 -rw-r--r-- root/root    usr/share/man/man1/grep.1.gz

--- a/main/grep/spkgbuild
+++ b/main/grep/spkgbuild
@@ -2,7 +2,7 @@
 # depends	: pcre
 
 name=grep
-version=3.8
+version=3.7
 release=1
 source="https://ftp.gnu.org/gnu/$name/$name-$version.tar.xz"
 


### PR DESCRIPTION
Reverts venomlinux/ports#1606. 

The new version causes warnings in some scripts, when the scripts are updated to work correctly with the new version, grep will be updated again.