### PR TITLE
Revert "Update harfbuzz to 5.2.0"

### DIFF
--- a/main/harfbuzz/.checksums
+++ b/main/harfbuzz/.checksums
@@ -1,1 +1,1 @@
-9e0bd000f1e620cdbd4abd17b4d4beee  harfbuzz-5.2.0.tar.xz
+76faebc692afe666520cc158430f1a14  harfbuzz-5.1.0.tar.xz

--- a/main/harfbuzz/.pkgfiles
+++ b/main/harfbuzz/.pkgfiles
@@ -1,4 +1,4 @@
-harfbuzz-5.2.0-1
+harfbuzz-5.1.0-1
 drwxr-xr-x root/root    usr/
 drwxr-xr-x root/root    usr/bin/
 -rwxr-xr-x root/root    usr/bin/hb-ot-shape-closure
@@ -22,7 +22,6 @@ drwxr-xr-x root/root    usr/include/harfbuzz/
 -rw-r--r-- root/root    usr/include/harfbuzz/hb-gobject-enums.h
 -rw-r--r-- root/root    usr/include/harfbuzz/hb-gobject-structs.h
 -rw-r--r-- root/root    usr/include/harfbuzz/hb-gobject.h
--rw-r--r-- root/root    usr/include/harfbuzz/hb-icu.h
 -rw-r--r-- root/root    usr/include/harfbuzz/hb-map.h
 -rw-r--r-- root/root    usr/include/harfbuzz/hb-ot-color.h
 -rw-r--r-- root/root    usr/include/harfbuzz/hb-ot-deprecated.h
@@ -51,20 +50,16 @@ drwxr-xr-x root/root    usr/lib/cmake/harfbuzz/
 drwxr-xr-x root/root    usr/lib/girepository-1.0/
 -rw-r--r-- root/root    usr/lib/girepository-1.0/HarfBuzz-0.0.typelib
 lrwxrwxrwx root/root    usr/lib/libharfbuzz-gobject.so -> libharfbuzz-gobject.so.0
-lrwxrwxrwx root/root    usr/lib/libharfbuzz-gobject.so.0 -> libharfbuzz-gobject.so.0.50200.0
--rwxr-xr-x root/root    usr/lib/libharfbuzz-gobject.so.0.50200.0
-lrwxrwxrwx root/root    usr/lib/libharfbuzz-icu.so -> libharfbuzz-icu.so.0
-lrwxrwxrwx root/root    usr/lib/libharfbuzz-icu.so.0 -> libharfbuzz-icu.so.0.50200.0
--rwxr-xr-x root/root    usr/lib/libharfbuzz-icu.so.0.50200.0
+lrwxrwxrwx root/root    usr/lib/libharfbuzz-gobject.so.0 -> libharfbuzz-gobject.so.0.50100.0
+-rwxr-xr-x root/root    usr/lib/libharfbuzz-gobject.so.0.50100.0
 lrwxrwxrwx root/root    usr/lib/libharfbuzz-subset.so -> libharfbuzz-subset.so.0
-lrwxrwxrwx root/root    usr/lib/libharfbuzz-subset.so.0 -> libharfbuzz-subset.so.0.50200.0
--rwxr-xr-x root/root    usr/lib/libharfbuzz-subset.so.0.50200.0
+lrwxrwxrwx root/root    usr/lib/libharfbuzz-subset.so.0 -> libharfbuzz-subset.so.0.50100.0
+-rwxr-xr-x root/root    usr/lib/libharfbuzz-subset.so.0.50100.0
 lrwxrwxrwx root/root    usr/lib/libharfbuzz.so -> libharfbuzz.so.0
-lrwxrwxrwx root/root    usr/lib/libharfbuzz.so.0 -> libharfbuzz.so.0.50200.0
--rwxr-xr-x root/root    usr/lib/libharfbuzz.so.0.50200.0
+lrwxrwxrwx root/root    usr/lib/libharfbuzz.so.0 -> libharfbuzz.so.0.50100.0
+-rwxr-xr-x root/root    usr/lib/libharfbuzz.so.0.50100.0
 drwxr-xr-x root/root    usr/lib/pkgconfig/
 -rw-r--r-- root/root    usr/lib/pkgconfig/harfbuzz-gobject.pc
--rw-r--r-- root/root    usr/lib/pkgconfig/harfbuzz-icu.pc
 -rw-r--r-- root/root    usr/lib/pkgconfig/harfbuzz-subset.pc
 -rw-r--r-- root/root    usr/lib/pkgconfig/harfbuzz.pc
 drwxr-xr-x root/root    usr/share/

--- a/main/harfbuzz/spkgbuild
+++ b/main/harfbuzz/spkgbuild
@@ -2,7 +2,7 @@
 # depends	: meson glib gobject-introspection cairo
 
 name=harfbuzz
-version=5.2.0
+version=5.1.0
 release=1
 source="https://github.com/harfbuzz/harfbuzz/releases/download/$version/harfbuzz-$version.tar.xz"
 


### PR DESCRIPTION
Reverts venomlinux/ports#1773, build error.