### PR TITLE
Revert "Update harfbuzz-icu to 5.2.0"

### DIFF
--- a/main/harfbuzz-icu/.checksums
+++ b/main/harfbuzz-icu/.checksums
@@ -1,1 +1,1 @@
-9e0bd000f1e620cdbd4abd17b4d4beee  harfbuzz-5.2.0.tar.xz
+76faebc692afe666520cc158430f1a14  harfbuzz-5.1.0.tar.xz

--- a/main/harfbuzz-icu/.pkgfiles
+++ b/main/harfbuzz-icu/.pkgfiles
@@ -1,11 +1,11 @@
-harfbuzz-icu-5.2.0-1
+harfbuzz-icu-5.1.0-1
 drwxr-xr-x root/root    usr/
 drwxr-xr-x root/root    usr/include/
 drwxr-xr-x root/root    usr/include/harfbuzz/
 -rw-r--r-- root/root    usr/include/harfbuzz/hb-icu.h
 drwxr-xr-x root/root    usr/lib/
 lrwxrwxrwx root/root    usr/lib/libharfbuzz-icu.so -> libharfbuzz-icu.so.0
-lrwxrwxrwx root/root    usr/lib/libharfbuzz-icu.so.0 -> libharfbuzz-icu.so.0.50200.0
--rwxr-xr-x root/root    usr/lib/libharfbuzz-icu.so.0.50200.0
+lrwxrwxrwx root/root    usr/lib/libharfbuzz-icu.so.0 -> libharfbuzz-icu.so.0.50100.0
+-rwxr-xr-x root/root    usr/lib/libharfbuzz-icu.so.0.50100.0
 drwxr-xr-x root/root    usr/lib/pkgconfig/
 -rw-r--r-- root/root    usr/lib/pkgconfig/harfbuzz-icu.pc

--- a/main/harfbuzz-icu/spkgbuild
+++ b/main/harfbuzz-icu/spkgbuild
@@ -2,7 +2,7 @@
 # depends	: harfbuzz icu
 
 name=harfbuzz-icu
-version=5.2.0
+version=5.1.0
 release=1
 source="https://github.com/harfbuzz/harfbuzz/releases/download/$version/harfbuzz-$version.tar.xz"
 


### PR DESCRIPTION
Reverts venomlinux/ports#1772, build error.