### PR TITLE
Revert "Update at-spi2-core to 2.46.0"

### DIFF
--- a/main/at-spi2-core/.checksums
+++ b/main/at-spi2-core/.checksums
@@ -1,1 +1,1 @@
-16e85a40442d80be960b4e1e3992fd5b  at-spi2-core-2.46.0.tar.xz
+7e30e7c82879ef13a76891dccee723cb  at-spi2-core-2.44.1.tar.xz

--- a/main/at-spi2-core/.pkgfiles
+++ b/main/at-spi2-core/.pkgfiles
@@ -1,4 +1,4 @@
-at-spi2-core-2.46.0-1
+at-spi2-core-2.44.1-1
 drwxr-xr-x root/root    etc/
 drwxr-xr-x root/root    etc/xdg/
 drwxr-xr-x root/root    etc/xdg/Xwayland-session.d/
@@ -40,71 +40,16 @@ drwxr-xr-x root/root    usr/include/at-spi-2.0/atspi/
 -rw-r--r-- root/root    usr/include/at-spi-2.0/atspi/atspi-types.h
 -rw-r--r-- root/root    usr/include/at-spi-2.0/atspi/atspi-value.h
 -rw-r--r-- root/root    usr/include/at-spi-2.0/atspi/atspi.h
-drwxr-xr-x root/root    usr/include/at-spi2-atk/
-drwxr-xr-x root/root    usr/include/at-spi2-atk/2.0/
--rw-r--r-- root/root    usr/include/at-spi2-atk/2.0/atk-bridge.h
-drwxr-xr-x root/root    usr/include/atk-1.0/
-drwxr-xr-x root/root    usr/include/atk-1.0/atk/
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atk-autocleanups.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atk-enum-types.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atk.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkaction.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkcomponent.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkdocument.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkeditabletext.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkgobjectaccessible.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkhyperlink.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkhyperlinkimpl.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkhypertext.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkimage.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkmisc.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atknoopobject.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atknoopobjectfactory.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkobject.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkobjectfactory.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkplug.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkrange.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkregistry.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkrelation.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkrelationset.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkrelationtype.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkselection.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atksocket.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkstate.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkstateset.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkstreamablecontent.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atktable.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atktablecell.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atktext.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkutil.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkvalue.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkversion.h
--rw-r--r-- root/root    usr/include/atk-1.0/atk/atkwindow.h
 drwxr-xr-x root/root    usr/lib/
 drwxr-xr-x root/root    usr/lib/at-spi2-core/
 -rwxr-xr-x root/root    usr/lib/at-spi2-core/at-spi-bus-launcher
 -rwxr-xr-x root/root    usr/lib/at-spi2-core/at-spi2-registryd
 drwxr-xr-x root/root    usr/lib/girepository-1.0/
--rw-r--r-- root/root    usr/lib/girepository-1.0/Atk-1.0.typelib
 -rw-r--r-- root/root    usr/lib/girepository-1.0/Atspi-2.0.typelib
-drwxr-xr-x root/root    usr/lib/gnome-settings-daemon-3.0/
-drwxr-xr-x root/root    usr/lib/gnome-settings-daemon-3.0/gtk-modules/
--rw-r--r-- root/root    usr/lib/gnome-settings-daemon-3.0/gtk-modules/at-spi2-atk.desktop
-drwxr-xr-x root/root    usr/lib/gtk-2.0/
-drwxr-xr-x root/root    usr/lib/gtk-2.0/modules/
--rwxr-xr-x root/root    usr/lib/gtk-2.0/modules/libatk-bridge.so
-lrwxrwxrwx root/root    usr/lib/libatk-1.0.so -> libatk-1.0.so.0
-lrwxrwxrwx root/root    usr/lib/libatk-1.0.so.0 -> libatk-1.0.so.0.24609.1
--rwxr-xr-x root/root    usr/lib/libatk-1.0.so.0.24609.1
-lrwxrwxrwx root/root    usr/lib/libatk-bridge-2.0.so -> libatk-bridge-2.0.so.0
-lrwxrwxrwx root/root    usr/lib/libatk-bridge-2.0.so.0 -> libatk-bridge-2.0.so.0.0.0
--rwxr-xr-x root/root    usr/lib/libatk-bridge-2.0.so.0.0.0
 lrwxrwxrwx root/root    usr/lib/libatspi.so -> libatspi.so.0
 lrwxrwxrwx root/root    usr/lib/libatspi.so.0 -> libatspi.so.0.0.1
 -rwxr-xr-x root/root    usr/lib/libatspi.so.0.0.1
 drwxr-xr-x root/root    usr/lib/pkgconfig/
--rw-r--r-- root/root    usr/lib/pkgconfig/atk-bridge-2.0.pc
--rw-r--r-- root/root    usr/lib/pkgconfig/atk.pc
 -rw-r--r-- root/root    usr/lib/pkgconfig/atspi-2.pc
 drwxr-xr-x root/root    usr/share/
 drwxr-xr-x root/root    usr/share/dbus-1/
@@ -116,5 +61,4 @@ drwxr-xr-x root/root    usr/share/defaults/
 drwxr-xr-x root/root    usr/share/defaults/at-spi2/
 -rw-r--r-- root/root    usr/share/defaults/at-spi2/accessibility.conf
 drwxr-xr-x root/root    usr/share/gir-1.0/
--rw-r--r-- root/root    usr/share/gir-1.0/Atk-1.0.gir
 -rw-r--r-- root/root    usr/share/gir-1.0/Atspi-2.0.gir

--- a/main/at-spi2-core/spkgbuild
+++ b/main/at-spi2-core/spkgbuild
@@ -2,7 +2,7 @@
 # depends	: dbus glib libxtst gobject-introspection meson
 
 name=at-spi2-core
-version=2.46.0
+version=2.44.1
 release=1
 source="https://ftp.gnome.org/pub/gnome/sources/$name/${version%.*}/$name-$version.tar.xz"
 


### PR DESCRIPTION
Reverts venomlinux/ports#1787. Conflicts found.