### PR TITLE
iproute2: update sources

### DIFF
--- a/core/iproute2/.checksums
+++ b/core/iproute2/.checksums
@@ -1,1 +1,1 @@
-152f10c32822dd002961da6277d25646  iproute2-6.1.0.tar.xz
+f3ff4461e25dbc5ef1fb7a9167a9523d  iproute2-6.1.0.tar.xz

--- a/core/iproute2/.pkgfiles
+++ b/core/iproute2/.pkgfiles
@@ -1,4 +1,4 @@
-iproute2-6.1.0-1
+iproute2-6.1.0-2
 drwxr-xr-x root/root    etc/
 drwxr-xr-x root/root    etc/iproute2/
 -rw-r--r-- root/root    etc/iproute2/bpf_pinning

--- a/core/iproute2/spkgbuild
+++ b/core/iproute2/spkgbuild
@@ -3,11 +3,11 @@
 
 name=iproute2
 version=6.1.0
-release=1
-source="$name-$version.tar.xz::https://www.kernel.org/pub/linux/utils/net/$name/$name-v$version.tar.xz"
+release=2
+source="https://www.kernel.org/pub/linux/utils/net/$name/$name-$version.tar.xz"
 
 build() {
-	cd $name-v$version
+	cd $name-$version
 
 	sed -i /ARPD/d Makefile
 	rm -fv man/man8/arpd.8


### PR DESCRIPTION
This release added a "v" to the version in the download sources tarball, now they have removed it again, I update again the sources only.