### PR TITLE
firefox: rebuild for new tarball

### DIFF
--- a/main/firefox/.checksums
+++ b/main/firefox/.checksums
@@ -1,4 +1,4 @@
 c93f8532a851264a6f84059993ff5111  0001-Squashed-ffmpeg-6.0-update.patch
 b631001051e06bec3f6e24cce7990994  0002-Use-correct-FFVPX-headers-from-ffmpeg-6.patch
-7c66ac643bc6d76ef062267b7976ebd5  firefox-111.0.1.source.tar.xz
+4c259560dfb941e087c1184af4612331  firefox-111.0.1.tar.xz
 971c77648caea312fca2d9340c4382a6  firefox.desktop

--- a/main/firefox/.pkgfiles
+++ b/main/firefox/.pkgfiles
@@ -1,4 +1,4 @@
-firefox-111.0.1-1
+firefox-111.0.1-2
 drwxr-xr-x root/root    etc/
 drwxr-xr-x root/root    etc/revdep.d/
 -rw-r--r-- root/root    etc/revdep.d/firefox.conf

--- a/main/firefox/spkgbuild
+++ b/main/firefox/spkgbuild
@@ -3,8 +3,8 @@
 
 name=firefox
 version=111.0.1
-release=1
-source="https://archive.mozilla.org/pub/firefox/releases/$version/source/firefox-$version.source.tar.xz 
+release=2
+source="$name-$version.tar.xz::https://archive.mozilla.org/pub/firefox/releases/$version/source/firefox-$version.source.tar.xz 
 	$name.desktop
 	0001-Squashed-ffmpeg-6.0-update.patch
 	0002-Use-correct-FFVPX-headers-from-ffmpeg-6.patch"


### PR DESCRIPTION
mozilla republished their 111.0.1 tarball. the diff contains:

2587,2588c2587,2589
<   if (!nsCRT::strcmp(aTopic, "profile-do-change")) {
<     // the profile has already changed; init the db from the new location
---
>   if (!nsCRT::strcmp(aTopic, "profile-do-change") && !mPermissionsFile) {
>     // profile startup is complete, and we didn't have the permissions file
>     // before; init the db from the new location

diff: https://hg.mozilla.org/releases/mozilla-release/rev/6e9b4327e238def619d5640de74b611fe51834ba