### PR TITLE
lua: downgrade to 5.4.4 (upstream removed  5.4.5 sources)

### DIFF
--- a/main/lua/.checksums
+++ b/main/lua/.checksums
@@ -1,3 +1,3 @@
 11bf137f084ead58422fdd2571b821c4  liblua.so.patch
-70fe23790cfb956d595806b2b6f4ce27  lua-5.4.5.tar.gz
+bd8ce7069ff99a400efd14cf339a727b  lua-5.4.4.tar.gz
 deee148134a3fede4595152e34d8cdc7  lua.pc

--- a/main/lua/.pkgfiles
+++ b/main/lua/.pkgfiles
@@ -1,4 +1,4 @@
-lua-5.4.5-1
+lua-5.4.4-1
 drwxr-xr-x root/root    usr/
 drwxr-xr-x root/root    usr/bin/
 -rwxr-xr-x root/root    usr/bin/lua
@@ -10,9 +10,9 @@ drwxr-xr-x root/root    usr/include/
 -rw-r--r-- root/root    usr/include/luaconf.h
 -rw-r--r-- root/root    usr/include/lualib.h
 drwxr-xr-x root/root    usr/lib/
-lrwxrwxrwx root/root    usr/lib/liblua.so -> liblua.so.5.4.5
-lrwxrwxrwx root/root    usr/lib/liblua.so.5.4 -> liblua.so.5.4.5
--rwxr-xr-x root/root    usr/lib/liblua.so.5.4.5
+lrwxrwxrwx root/root    usr/lib/liblua.so -> liblua.so.5.4.4
+lrwxrwxrwx root/root    usr/lib/liblua.so.5.4 -> liblua.so.5.4.4
+-rwxr-xr-x root/root    usr/lib/liblua.so.5.4.4
 drwxr-xr-x root/root    usr/lib/lua/
 drwxr-xr-x root/root    usr/lib/lua/5.4/
 drwxr-xr-x root/root    usr/lib/pkgconfig/

--- a/main/lua/spkgbuild
+++ b/main/lua/spkgbuild
@@ -1,7 +1,7 @@
 # description	: Light-weight programming language designed for extending applications
 
 name=lua
-version=5.4.5
+version=5.4.4
 _majorver=${version%.*}
 release=1
 source="https://www.lua.org/ftp/$name-$version.tar.gz


### PR DESCRIPTION
Notice from upstream:
_The current release is [Lua 5.4.4](https://www.lua.org/ftp/lua-5.4.4.tar.gz), released on 26 Jan 2022. We are getting ready to release [Lua 5.4.6](https://www.lua.org/work/)._