### PR TITLE
New package: limine-4.20230514.0.

### DIFF
--- a/main/limine/.checksums
+++ b/main/limine/.checksums
@@ -1,0 +1,1 @@
+8e5ebeaa52475840e7daec13affeb781  limine-4.20230514.0.tar.xz

--- a/main/limine/.pkgfiles
+++ b/main/limine/.pkgfiles
@@ -10,6 +10,7 @@ drwxr-xr-x root/root    usr/share/
 drwxr-xr-x root/root    usr/share/limine/
 -rw-r--r-- root/root    usr/share/limine/BOOTIA32.EFI
 -rw-r--r-- root/root    usr/share/limine/BOOTX64.EFI
+-rw-r--r-- root/root    usr/share/limine/limine-cd-efi.bin
 -rw-r--r-- root/root    usr/share/limine/limine-cd.bin
 -rw-r--r-- root/root    usr/share/limine/limine-pxe.bin
 -rw-r--r-- root/root    usr/share/limine/limine.sys

--- a/main/limine/.pkgfiles
+++ b/main/limine/.pkgfiles
@@ -1,0 +1,20 @@
+limine-4.20230514.0-1
+drwxr-xr-x root/root    usr/
+drwxr-xr-x root/root    usr/bin/
+-rwxr-xr-x root/root    usr/bin/limine-deploy
+-rwxr-xr-x root/root    usr/bin/limine-enroll-config
+-rwxr-xr-x root/root    usr/bin/limine-version
+drwxr-xr-x root/root    usr/include/
+-rw-r--r-- root/root    usr/include/limine.h
+drwxr-xr-x root/root    usr/share/
+drwxr-xr-x root/root    usr/share/limine/
+-rw-r--r-- root/root    usr/share/limine/BOOTIA32.EFI
+-rw-r--r-- root/root    usr/share/limine/BOOTX64.EFI
+-rw-r--r-- root/root    usr/share/limine/limine-cd.bin
+-rw-r--r-- root/root    usr/share/limine/limine-pxe.bin
+-rw-r--r-- root/root    usr/share/limine/limine.sys
+drwxr-xr-x root/root    usr/share/man/
+drwxr-xr-x root/root    usr/share/man/man1/
+-rw-r--r-- root/root    usr/share/man/man1/limine-deploy.1.gz
+-rw-r--r-- root/root    usr/share/man/man1/limine-enroll-config.1.gz
+-rw-r--r-- root/root    usr/share/man/man1/limine-version.1.gz

--- a/main/limine/spkgbuild
+++ b/main/limine/spkgbuild
@@ -1,0 +1,21 @@
+# description	: Modern, advanced, portable, multiprotocol bootloader.
+# homepage	: https://limine-bootloader.org 
+# depends	: nasm mtools llvm lld clang
+
+name=limine
+version=4.20230514.0
+release=1
+source="https://github.com/limine-bootloader/limine/releases/download/v$version/limine-$version.tar.xz"
+
+build() {
+	cd $name-$version
+	./configure --prefix=/usr \
+		--enable-bios-cd \
+		--enable-bios-pxe \
+		--enable-bios \
+		--enable-uefi-x86-64 \
+		--enable-uefi-ia32 \
+		TOOLCHAIN_FOR_TARGET=llvm
+	make
+	make DESTDIR=$PKG install
+}

--- a/main/limine/spkgbuild
+++ b/main/limine/spkgbuild
@@ -15,6 +15,7 @@ build() {
 		--enable-bios \
 		--enable-uefi-x86-64 \
 		--enable-uefi-ia32 \
+		--enable-uefi-cd \
 		TOOLCHAIN_FOR_TARGET=llvm
 	make
 	make DESTDIR=$PKG install

--- a/main/limine/spkgbuild
+++ b/main/limine/spkgbuild
@@ -1,6 +1,6 @@
 # description	: Modern, advanced, portable, multiprotocol bootloader.
 # homepage	: https://limine-bootloader.org 
-# depends	: nasm mtools llvm lld clang
+# depends	: nasm mtools lld clang
 
 name=limine
 version=4.20230514.0


### PR DESCRIPTION
In this first release, `--enable-uefi-cd` is missing, because in my tests it breaks the build. I hope I can enable it in a future spkgbuild release :)
