### PR TITLE
Gnutls and dino fix

### DIFF
--- a/main/dino/spkgbuild
+++ b/main/dino/spkgbuild
@@ -1,10 +1,10 @@
 # description	: Modern XMPP (Jabber) chat client written in Vala 
-# depends	: glib-networking gpgme gspell gst-plugins-good gtk4 libadwaita libgcrypt libgee libnice libsignal-protocol-c libsoup3 libsrtp qrencode sqlite
+# depends	: glib-networking gpgme gspell gst-plugins-good gtk4 libadwaita libgcrypt libgee libnice libsignal-protocol-c libsoup3 libsrtp qrencode sqlite gnutls
 
 
 name=dino
 version=0.4.2
-release=2
+release=3
 source="https://github.com/dino/dino/releases/download/v${version}/${name}-${version}.tar.gz"
 
 build() {

--- a/main/gnutls/spkgbuild
+++ b/main/gnutls/spkgbuild
@@ -3,14 +3,14 @@
 
 name=gnutls
 version=3.8.0
-release=1
+release=2
 source="https://www.gnupg.org/ftp/gcrypt/gnutls/v${version%.*}/$name-${version}.tar.xz"
 
 build() {
 	cd $name-$version
 
 	./configure --prefix=/usr \
-		    --with-default-trust-store-pkcs11="pkcs11:" \
+		    --with-default-trust-store-file=/etc/ssl/certs/ca-certificates.crt \
 		    --disable-guile
 	make
 	make DESTDIR=$PKG install


### PR DESCRIPTION
- Add a default trust store for gnutls that works (the previous one was not, at least with dino).
- add a dependency on gnutls for dino.