### PR TITLE
waterfox: update to 5.1.9.

### DIFF
--- a/main/waterfox-bin/.checksums
+++ b/main/waterfox-bin/.checksums
@@ -1,1 +1,1 @@
-0deda5831bc6de71b5a9239678c8cc6c  waterfox-G5.1.3.tar.bz2
+bcdad64b764307838a80df56a91ec57b  waterfox-G5.1.9.tar.bz2

--- a/main/waterfox-bin/.pkgfiles
+++ b/main/waterfox-bin/.pkgfiles
@@ -1,10 +1,6 @@
-waterfox-bin-5.1.3-1
+waterfox-bin-5.1.9-1
 drwxr-xr-x root/root    opt/
 drwxr-xr-x root/root    opt/waterfox-g/
-drwxr-xr-x root/root    opt/waterfox-g/browser/
-drwxr-xr-x root/root    opt/waterfox-g/browser/defaults/
-drwxr-xr-x root/root    opt/waterfox-g/browser/defaults/preferences/
--rw-r--r-- root/root    opt/waterfox-g/browser/defaults/preferences/vendor.js
 drwxr-xr-x root/root    opt/waterfox-g/distribution/
 -rw-r--r-- root/root    opt/waterfox-g/distribution/policies.json
 drwxr-xr-x root/root    opt/waterfox/
@@ -21,6 +17,9 @@ drwxr-xr-x root/root    opt/waterfox/browser/chrome/icons/default/
 -rw-r--r-- root/root    opt/waterfox/browser/chrome/icons/default/default32.png
 -rw-r--r-- root/root    opt/waterfox/browser/chrome/icons/default/default48.png
 -rw-r--r-- root/root    opt/waterfox/browser/chrome/icons/default/default64.png
+drwxr-xr-x root/root    opt/waterfox/browser/defaults/
+drwxr-xr-x root/root    opt/waterfox/browser/defaults/preferences/
+-rw-r--r-- root/root    opt/waterfox/browser/defaults/preferences/vendor.js
 drwxr-xr-x root/root    opt/waterfox/browser/features/
 -rw-r--r-- root/root    opt/waterfox/browser/features/doh-rollout@mozilla.org.xpi
 -rw-r--r-- root/root    opt/waterfox/browser/features/formautofill@mozilla.org.xpi
@@ -72,7 +71,7 @@ drwxr-xr-x root/root    opt/waterfox/icons/
 -rwxr-xr-x root/root    opt/waterfox/waterfox-bin
 drwxr-xr-x root/root    usr/
 drwxr-xr-x root/root    usr/bin/
-lrwxrwxrwx root/root    usr/bin/waterfox-g -> /opt/waterfox-g4/waterfox
+lrwxrwxrwx root/root    usr/bin/waterfox -> /opt/waterfox/waterfox
 drwxr-xr-x root/root    usr/share/
 drwxr-xr-x root/root    usr/share/applications/
 -rw-r--r-- root/root    usr/share/applications/waterfox.desktop
@@ -80,16 +79,16 @@ drwxr-xr-x root/root    usr/share/icons/
 drwxr-xr-x root/root    usr/share/icons/hicolor/
 drwxr-xr-x root/root    usr/share/icons/hicolor/128x128/
 drwxr-xr-x root/root    usr/share/icons/hicolor/128x128/apps/
-lrwxrwxrwx root/root    usr/share/icons/hicolor/128x128/apps/waterfox-g.png -> /opt/waterfox-g4/browser/chrome/icons/default/default128.png
+lrwxrwxrwx root/root    usr/share/icons/hicolor/128x128/apps/waterfox.png -> /opt/waterfox/browser/chrome/icons/default/default128.png
 drwxr-xr-x root/root    usr/share/icons/hicolor/16x16/
 drwxr-xr-x root/root    usr/share/icons/hicolor/16x16/apps/
-lrwxrwxrwx root/root    usr/share/icons/hicolor/16x16/apps/waterfox-g.png -> /opt/waterfox-g4/browser/chrome/icons/default/default16.png
+lrwxrwxrwx root/root    usr/share/icons/hicolor/16x16/apps/waterfox.png -> /opt/waterfox/browser/chrome/icons/default/default16.png
 drwxr-xr-x root/root    usr/share/icons/hicolor/32x32/
 drwxr-xr-x root/root    usr/share/icons/hicolor/32x32/apps/
-lrwxrwxrwx root/root    usr/share/icons/hicolor/32x32/apps/waterfox-g.png -> /opt/waterfox-g4/browser/chrome/icons/default/default32.png
+lrwxrwxrwx root/root    usr/share/icons/hicolor/32x32/apps/waterfox.png -> /opt/waterfox/browser/chrome/icons/default/default32.png
 drwxr-xr-x root/root    usr/share/icons/hicolor/48x48/
 drwxr-xr-x root/root    usr/share/icons/hicolor/48x48/apps/
-lrwxrwxrwx root/root    usr/share/icons/hicolor/48x48/apps/waterfox-g.png -> /opt/waterfox-g4/browser/chrome/icons/default/default48.png
+lrwxrwxrwx root/root    usr/share/icons/hicolor/48x48/apps/waterfox.png -> /opt/waterfox/browser/chrome/icons/default/default48.png
 drwxr-xr-x root/root    usr/share/icons/hicolor/64x64/
 drwxr-xr-x root/root    usr/share/icons/hicolor/64x64/apps/
-lrwxrwxrwx root/root    usr/share/icons/hicolor/64x64/apps/waterfox-g.png -> /opt/waterfox-g4/browser/chrome/icons/default/default64.png
+lrwxrwxrwx root/root    usr/share/icons/hicolor/64x64/apps/waterfox.png -> /opt/waterfox/browser/chrome/icons/default/default64.png

--- a/main/waterfox-bin/spkgbuild
+++ b/main/waterfox-bin/spkgbuild
@@ -1,9 +1,9 @@
-# description	: Waterfox-g4 binary Fourth generation of customizable privacy-conscious web browser.
+# description	: Waterfox - customizable privacy-conscious web browser.
 # homepage	: https://www.waterfox.net
 # depends	: gtk3 gtk2 libxt startup-notification shared-mime-info dbus-glib ffmpeg 
 
 name=waterfox-bin
-version=5.1.3
+version=5.1.9
 release=1
 source="https://cdn1.waterfox.net/waterfox/releases/G$version/Linux_x86_64/waterfox-G$version.tar.bz2"
 
@@ -26,12 +26,12 @@ build() {
 	# Install icons
     for i in 16 32 48 64 128; do
         install -d "$PKG/usr/share/icons/hicolor/${i}x${i}/apps"
-        ln -Ts /opt/waterfox-g4/browser/chrome/icons/default/default$i.png \
-            "$PKG/usr/share/icons/hicolor/${i}x${i}/apps/waterfox-g.png"
+        ln -Ts /opt/waterfox/browser/chrome/icons/default/default$i.png \
+            "$PKG/usr/share/icons/hicolor/${i}x${i}/apps/waterfox.png"
     done
 
     # Add additional useful settings
-    install -Dm644 /dev/stdin "$PKG/opt/waterfox-g/browser/defaults/preferences/vendor.js" <<END
+    install -Dm644 /dev/stdin "$PKG/opt/waterfox/browser/defaults/preferences/vendor.js" <<END
 // Disable default browser checking
 pref("browser.shell.checkDefaultBrowser", false);
 
@@ -56,5 +56,5 @@ END
 END
 
 	# Symlink the binary to /usr/bin/.
-	ln -s /opt/waterfox-g4/waterfox "$PKG"/usr/bin/waterfox-g
+	ln -s /opt/waterfox/waterfox "$PKG"/usr/bin/waterfox
 }

--- a/main/waterfox-bin/waterfox.desktop
+++ b/main/waterfox-bin/waterfox.desktop
@@ -1,12 +1,12 @@
 [Desktop Entry]
-Name=Waterfox-G4
+Name=Waterfox
 Name[en_US]=waterfox
 GenericName=Web Browser
 GenericName[en_US]=Web Browser
 Comment=Free web browser fork of  Mozilla
-Exec=waterfox-g4-bin %U
+Exec=waterfox %U
 Terminal=false
 Type=Application
-Icon=waterfox-g4:
+Icon=waterfox
 Categories=Network;
 


### PR DESCRIPTION
Also:
- fix spkgbuild to use the waterfox name everywhere
- fix icon.

Fixes https://github.com/venomlinux/ports/issues/5686.