### PR TITLE
firefox: disable 'wayland-only'

### DIFF
--- a/main/firefox/spkgbuild
+++ b/main/firefox/spkgbuild
@@ -82,7 +82,7 @@ EOF
 
   # wayland
   scratch isinstalled wayland-protocols && \
-    echo 'ac_add_options --enable-default-toolkit=cairo-gtk3-wayland-only' >> .mozconfig || \
+    echo 'ac_add_options --enable-default-toolkit=cairo-gtk3-wayland' >> .mozconfig || \
     echo 'ac_add_options --enable-default-toolkit=cairo-gtk3' >> .mozconfig
 
   # Build configuration


### PR DESCRIPTION
The binary build with 'wayland-only' don't run over Xorg, with 'wayland' yes.