### PR TITLE
Fix linux-libre build with ssl

### DIFF
--- a/main/linux-libre/.checksums
+++ b/main/linux-libre/.checksums
@@ -1,2 +1,3 @@
+1eb4f5bbd99f8546eb6ba07d24776550  0001-scripts-Fix-libressl-check.patch
 76b99b5a6f09c4909466dd8580428152  linux-libre-6.6.5.tar.xz
 8da5c98a79325e3d451089b12d2e5d51  x86-64-gnu

--- a/main/linux-libre/.pkgfiles
+++ b/main/linux-libre/.pkgfiles
@@ -1,4 +1,4 @@
-linux-libre-6.6.5-1
+linux-libre-6.6.5-2
 drwxr-xr-x root/root    boot/
 -rw-r--r-- root/root    boot/config-venom-gnu
 -rw-r--r-- root/root    boot/vmlinuz-venom-gnu

--- a/main/linux-libre/0001-scripts-Fix-libressl-check.patch
+++ b/main/linux-libre/0001-scripts-Fix-libressl-check.patch
@@ -1,0 +1,18 @@
+diff --git a/scripts/sign-file.c b/scripts/sign-file.c
+index fbd34b8e8f57..fd4d7c31d1bf 100644
+--- a/scripts/sign-file.c  2023-12-09 19:57:13.159393154 -0800
++++ b/scripts/sign-file.c  2023-12-09 19:57:13.159393154 -0800
+@@ -48,9 +48,10 @@
+  * signing with anything other than SHA1 - so we're stuck with that if such is
+  * the case.
+  */
+-#if defined(LIBRESSL_VERSION_NUMBER) || \
+-	OPENSSL_VERSION_NUMBER < 0x10000000L || \
+-	defined(OPENSSL_NO_CMS)
++#if defined(OPENSSL_NO_CMS) || \
++    ( defined(LIBRESSL_VERSION_NUMBER) \
++    && (LIBRESSL_VERSION_NUMBER < 0x3010000fL) ) || \
++    OPENSSL_VERSION_NUMBER < 0x10000000L
+ #define USE_PKCS7
+ #endif
+ #ifndef USE_PKCS7

--- a/main/linux-libre/spkgbuild
+++ b/main/linux-libre/spkgbuild
@@ -3,14 +3,15 @@
 
 name=linux-libre
 version=6.6.5
-release=1
+release=2
 source="${name}-${version}.tar.xz::https://linux-libre.fsfla.org/pub/linux-libre/releases/${version%.0}-gnu/${name}-${version%.0}-gnu.tar.xz
-	x86-64-gnu"
+	x86-64-gnu
+        0001-scripts-Fix-libressl-check.patch"
 NO_STRIP=yes
 
 build() {
 	cd ${name%-*}-${version%.0}
-	
+	patch -Np1 -i ../0001-scripts-Fix-libressl-check.patch
 	make mrproper
 
 	cp $SRC/x86-64-gnu ./.config


### PR DESCRIPTION
Idk why but linux don't want to use cms even when it is supported since 2.5. This break the way libressl sign with sha256
This pach is from https://patchwork.kernel.org/project/keyrings/patch/f13b4174-bcfa-6569-0601-65a9bfc9bb92@rosalinux.ru/